### PR TITLE
Redirect RTP/RTCP packets

### DIFF
--- a/rtsp-proxy.c
+++ b/rtsp-proxy.c
@@ -37,6 +37,10 @@ char *prg;
 int debug=0;
 char *lport=DEFAULT_RTSP_PORT;
 char *srvip="0.0.0.0";
+char *redir_rtp="";
+int redir_dup=0;
+struct in_addr redir_ip;
+int redir_port;
 char *target;
 char *port;
 int udp_recv_port=15000;
@@ -59,10 +63,13 @@ struct SESSION {
 
 void usage()
 {
-    fprintf(stderr,"usage: %s [-d] [-d] [-d] [-d] [-i <srvip>] [-p <port>] [-r <rport>] <target>\n"
+    fprintf(stderr,"usage: %s [-d] [-d] [-d] [-d] [-i <srvip>] [-p <port>] [-r <rport>] [-t|-T <targetip:targetport>] <target>\n"
 	           "    srvip: ip to listen to (default 0.0.0.0 = any)\n"
 		   "    port: tcp port to listen and connect to rtsp (default 554)\n"
-		   "    rport: base udp port to receive RTP packets (default 15000)\n",prg);
+		   "    rport: base udp port to receive RTP packets (default 15000)\n"
+		   "    targetip: ip to send RTP/RTCP packets instead of the client address (optional)\n"
+		   "    targetport: port to send RTP/RTCP packets (default 16000)\n"
+		   "    -t|-T: with the lower all packets are redirected, with upper are duplicated\n",prg);
 }
 
 struct pollfd lfd[MAXOPENFDS];
@@ -75,6 +82,7 @@ struct LFD_M {
     struct SESSION *sessionpointer;
     struct in_addr client_ip;
     struct sockaddr_in saddr;
+    struct sockaddr_in saddr_cpy;
     int deleted;
     char srvip[64];
 } lfd_m[MAXOPENFDS];
@@ -416,6 +424,16 @@ int start_udp_proxy(struct SESSION *s,struct in_addr client_ip,int client_port)
     lfd_m[nfd].saddr.sin_port=ntohs(client_port);
     lfd_m[nfd].lastact=now;
     lfd_m[nfd].deleted=FALSE;
+    if (redir_rtp[0] != 0)
+    {
+        lfd_m[nfd].saddr_cpy.sin_addr=redir_ip;
+        lfd_m[nfd].saddr_cpy.sin_port=ntohs(redir_port);
+        if (!redir_dup)
+        {
+            lfd_m[nfd].saddr.sin_addr=lfd_m[nfd].saddr_cpy.sin_addr;
+            lfd_m[nfd].saddr.sin_port=lfd_m[nfd].saddr_cpy.sin_port;
+        }
+    }
     nfd++; 
 
     fd=open_udp(srvip,udp_recv_port+1);
@@ -432,6 +450,16 @@ int start_udp_proxy(struct SESSION *s,struct in_addr client_ip,int client_port)
     lfd_m[nfd].saddr.sin_port=ntohs(client_port+1);
     lfd_m[nfd].lastact=now;
     lfd_m[nfd].deleted=FALSE;
+    if (redir_rtp[0] != 0)
+    {
+        lfd_m[nfd].saddr_cpy.sin_addr=redir_ip;
+        lfd_m[nfd].saddr_cpy.sin_port=ntohs(redir_port+1);
+        if (!redir_dup)
+        {
+            lfd_m[nfd].saddr.sin_addr=lfd_m[nfd].saddr_cpy.sin_addr;
+            lfd_m[nfd].saddr.sin_port=lfd_m[nfd].saddr_cpy.sin_port;
+        }
+    }
     nfd++; 
 
     udp_recv_port+=2;
@@ -791,14 +819,20 @@ void poll_loop(int accsock)
 			if (lfd_m[i].type==f_udprcv)
 			{
     			    len = recv(lfd[i].fd, lfd_m[i].inbuf, MAXREQUESTLEN, 0);
+                            if (redir_rtp[0] != 0 && debug>3) fprintf(stderr," %s TO %s:%u <<<", (redir_dup)? "DUPLICATED" : "REDIRECTED", inet_ntoa(lfd_m[i].saddr_cpy.sin_addr), ntohs(lfd_m[i].saddr_cpy.sin_port));
                             if (debug>3) fprintf(stderr,"<<<  UDP packet (bytes:%d) <<<\n",len);
                             sendto(lfd[i].fd,lfd_m[i].inbuf,len,0,&lfd_m[i].saddr,sizeof(lfd_m[i].saddr));
-                            continue;
+                            if (redir_dup)
+                                sendto(lfd[i].fd,lfd_m[i].inbuf,len,0,&lfd_m[i].saddr_cpy,sizeof(lfd_m[i].saddr_cpy));
+                             continue;
                         }
                         if (lfd_m[i].type==f_rtcp)
                         {
                             len = recv(lfd[i].fd, lfd_m[i].inbuf, MAXREQUESTLEN, 0);
                             sendto(lfd[i].fd,lfd_m[i].inbuf,len,0,&lfd_m[i].saddr,sizeof(lfd_m[i].saddr));
+                            if (redir_dup)
+                                sendto(lfd[i].fd,lfd_m[i].inbuf,len,0,&lfd_m[i].saddr_cpy,sizeof(lfd_m[i].saddr_cpy));
+                            if (redir_rtp[0] != 0 && debug>2) fprintf(stderr," RTCP %s TO %s:%u \n", (redir_dup)? "DUPLICATED" : "REDIRECTED", inet_ntoa(lfd_m[i].saddr_cpy.sin_addr), ntohs(lfd_m[i].saddr_cpy.sin_port));
                             for(j=0;j<len;j++)
                             {
                                 if(lfd_m[i].inbuf[j]<32 || lfd_m[i].inbuf[j]>126)
@@ -883,7 +917,7 @@ int main(int argc,char **argv)
     char *p;
 	
     prg=argv[0];
-    while ((ch=getopt(argc,argv,"di:p:r:"))!= EOF)
+    while ((ch=getopt(argc,argv,"di:p:r:t:T:"))!= EOF)
     {
         switch(ch)
         {
@@ -891,6 +925,9 @@ int main(int argc,char **argv)
             case 'i':   srvip=optarg; break;
             case 'p':   lport=optarg; break;
             case 'r':   udp_recv_port=atoi(optarg); break;
+            case 'T':   redir_dup=1;
+            case 't':   if (redir_rtp[0] == 0) { redir_rtp=optarg; break; }
+                            else { fprintf(stderr,"-t and -T options are incompatible\n"); exit(1); }
             default:    usage(); exit(1); 
         }
     }
@@ -907,11 +944,25 @@ int main(int argc,char **argv)
     {
         fprintf(stderr,"Using target SAT>IP server %s with port %s\n",target,port);
         fprintf(stderr,"Listening in address %s at port %s\n",srvip,lport);
-        fprintf(stderr,"Configured RTP receive ports %d-%d,..\n",udp_recv_port,udp_recv_port+1);
+        fprintf(stderr,"Configured RTP receive ports %d-%d\n",udp_recv_port,udp_recv_port+1);
+        if (redir_rtp[0] != 0)
+            fprintf(stderr,"Target RTP/RTCP: %s\n",redir_rtp);
     }
 
     accsock=prepare_socket(srvip,lport);
     if (accsock==-1) exit(3);
+
+    if (redir_rtp[0] != 0)
+    {
+        p=strchr(redir_rtp,':');
+        if (p) { *p=0; redir_port=atoi(p+1); } else { redir_port=16000; }
+        struct hostent *phent;
+        phent=gethostbyname(redir_rtp);
+        if (phent==NULL) { fprintf(stderr,"gethostbyname(%s) failed\n",redir_rtp); exit(3); }
+        memmove(&redir_ip,phent->h_addr,sizeof(redir_ip));
+        if (debug>1)
+            fprintf(stderr,"Resolved address for target RTP/RTCP: %s:%d\n", inet_ntoa(redir_ip), redir_port);
+    }
 
     poll_loop(accsock);
 

--- a/rtsp-proxy.c
+++ b/rtsp-proxy.c
@@ -67,8 +67,8 @@ void usage()
 	           "    srvip: ip to listen to (default 0.0.0.0 = any)\n"
 		   "    port: tcp port to listen and connect to rtsp (default 554)\n"
 		   "    rport: base udp port to receive RTP packets (default 15000)\n"
-		   "    targetip: ip to send RTP/RTCP packets instead of the client address (optional)\n"
-		   "    targetport: port to send RTP/RTCP packets (default 16000)\n"
+		   "    targetip: alternative address to send RTP/RTCP packets (optional)\n"
+		   "    targetport: alternative port to send RTP/RTCP packets (default 16000)\n"
 		   "    -t|-T: with the lower all packets are redirected, with upper are duplicated\n",prg);
 }
 
@@ -824,7 +824,7 @@ void poll_loop(int accsock)
                             sendto(lfd[i].fd,lfd_m[i].inbuf,len,0,&lfd_m[i].saddr,sizeof(lfd_m[i].saddr));
                             if (redir_dup)
                                 sendto(lfd[i].fd,lfd_m[i].inbuf,len,0,&lfd_m[i].saddr_cpy,sizeof(lfd_m[i].saddr_cpy));
-                             continue;
+                            continue;
                         }
                         if (lfd_m[i].type==f_rtcp)
                         {
@@ -946,7 +946,7 @@ int main(int argc,char **argv)
         fprintf(stderr,"Listening in address %s at port %s\n",srvip,lport);
         fprintf(stderr,"Configured RTP receive ports %d-%d\n",udp_recv_port,udp_recv_port+1);
         if (redir_rtp[0] != 0)
-            fprintf(stderr,"Target RTP/RTCP: %s\n",redir_rtp);
+            fprintf(stderr,"Alternative RTP/RTCP target: %s\n",redir_rtp);
     }
 
     accsock=prepare_socket(srvip,lport);
@@ -961,7 +961,7 @@ int main(int argc,char **argv)
         if (phent==NULL) { fprintf(stderr,"gethostbyname(%s) failed\n",redir_rtp); exit(3); }
         memmove(&redir_ip,phent->h_addr,sizeof(redir_ip));
         if (debug>1)
-            fprintf(stderr,"Resolved address for target RTP/RTCP: %s:%d\n", inet_ntoa(redir_ip), redir_port);
+            fprintf(stderr,"Resolved address for alternative RTP/RTCP target: %s:%d\n", inet_ntoa(redir_ip), redir_port);
     }
 
     poll_loop(accsock);


### PR DESCRIPTION
This patch provides a new functionality to redirect/duplicate the RTP/RTCP packets.

The new functionality will be useful on these scenarios:
- To debug the streaming duplicating the RTP flow to an analyzer. In this case the SAT>IP client is not disturbed.
- When using an external helper tool for tunneling the RTP flow. In this case, the external tool will receive the UDP packets and requires to send them to the SAT>IP client.

Besides that, it will probably be useful in other environments.
  