### PR TITLE
Optional parameter to reconnect RTSP client socket

### DIFF
--- a/rtsp-proxy.c
+++ b/rtsp-proxy.c
@@ -45,6 +45,7 @@ char  *target;
 char  *port;
 int    udp_recv_port=15000;
 int    idletimeout=120;
+int    nr_reconnects=-1;
 int    nr_sessions=0;
 time_t now;
 
@@ -63,8 +64,9 @@ struct SESSION {
 
 void usage()
 {
-    fprintf(stderr,"usage: %s [-d] [-d] [-d] [-d] [-i <srvip>] [-p <port>] [-r <rport>] [-t|-T <targetip:targetport>] <target>\n"
-	           "    srvip: ip to listen to (default 0.0.0.0 = any)\n"
+    fprintf(stderr,"usage: %s [-d] [-d] [-d] [-d] [-f <retries>] [-i <srvip>] [-p <port>] [-r <rport>] [-t|-T <targetip:targetport>] <target>\n"
+		   "    retries: max retries when fixing RTSP sessions reconnecting automatically (default -1: disabled)\n"
+		   "    srvip: ip to listen to (default 0.0.0.0 = any)\n"
 		   "    port: tcp port to listen and connect to rtsp (default 554)\n"
 		   "    rport: base udp port to receive RTP packets (default 15000)\n"
 		   "    targetip: alternative address to send RTP/RTCP packets (optional)\n"
@@ -83,6 +85,7 @@ struct LFD_M {
     struct in_addr client_ip;
     struct sockaddr_in saddr;
     struct sockaddr_in saddr_cpy;
+    int count_reconnect;
     int deleted;
     char srvip[64];
 } lfd_m[MAXOPENFDS];
@@ -330,6 +333,24 @@ void dropconnection(int n,int reason)
     remove_lfd(n+1);
 }
 
+int reconnect(int n, int* rev_count)
+{
+    if (debug)
+    {
+        fprintf(stderr,"%ld reconnecting (counter=%d) to %s: (%d/%d)\n",now,(rev_count)? *rev_count : -1,inet_ntoa(lfd_m[n].client_ip),n,nfd);
+    }
+    close(lfd[n].fd);
+    int newfd;
+    newfd=connect_server();
+    if (newfd >= 0)
+    {
+        lfd[n].fd=newfd;
+        if (rev_count) (*rev_count)--;
+        return newfd;
+    }
+    return -1;
+}
+
 int req_complete(char *s)
 {
     if(strstr(s,"\r\n\r\n")) return TRUE;
@@ -423,6 +444,7 @@ int start_udp_proxy(struct SESSION *s,struct in_addr client_ip,int client_port)
     lfd_m[nfd].saddr.sin_addr=client_ip;
     lfd_m[nfd].saddr.sin_port=ntohs(client_port);
     lfd_m[nfd].lastact=now;
+    lfd_m[nfd].count_reconnect=nr_reconnects;
     lfd_m[nfd].deleted=FALSE;
     if (redir_rtp[0] != 0)
     {
@@ -449,6 +471,7 @@ int start_udp_proxy(struct SESSION *s,struct in_addr client_ip,int client_port)
     lfd_m[nfd].saddr.sin_addr=client_ip;
     lfd_m[nfd].saddr.sin_port=ntohs(client_port+1);
     lfd_m[nfd].lastact=now;
+    lfd_m[nfd].count_reconnect=nr_reconnects;
     lfd_m[nfd].deleted=FALSE;
     if (redir_rtp[0] != 0)
     {
@@ -746,6 +769,7 @@ void poll_loop(int accsock)
     lfd[0].revents=0;
     lfd_m[0].lastact=now;
     lfd_m[0].type=f_accept;
+    lfd_m[0].count_reconnect=nr_reconnects;
     lfd_m[0].deleted=FALSE;
     nfd=1;
 
@@ -773,7 +797,7 @@ void poll_loop(int accsock)
                 if (lfd[0].revents&POLLIN && nfd<MAXOPENFDS-1)          // new connection coming in
                 {
                     nret--;
-		    sinlen=sizeof(struct sockaddr_in);
+                    sinlen=sizeof(struct sockaddr_in);
                     newfd=accept(accsock,(struct sockaddr *)&sin, &sinlen);
                     if (newfd<0) fprintf(stderr,"accept socket failed %s\n",strerror(errno));
                     else
@@ -781,10 +805,11 @@ void poll_loop(int accsock)
                         lfd[nfd].fd=newfd;
                         lfd[nfd].events=POLLIN|POLLPRI;
                         lfd[nfd].revents=0;
-			lfd_m[nfd].type=f_client;
-			lfd_m[nfd].inbuf_offset=0;
+                        lfd_m[nfd].type=f_client;
+                        lfd_m[nfd].inbuf_offset=0;
                         lfd_m[nfd].lastact=now;
                         lfd_m[nfd].client_ip=sin.sin_addr;
+                        lfd_m[nfd].count_reconnect=nr_reconnects;
                         lfd_m[nfd].deleted=FALSE;
                         nfd++; nc++;
 
@@ -843,7 +868,16 @@ void poll_loop(int accsock)
 			}
 
                         len=read(lfd[i].fd,lfd_m[i].inbuf+lfd_m[i].inbuf_offset,MAXREQUESTLEN-lfd_m[i].inbuf_offset);
-                        if (len<=0) dropconnection(i,2);
+                        if (len<=0)
+                        {
+                            int* rc = &(lfd_m[i].count_reconnect);
+                            if (lfd_m[i].type == f_server && *rc > 0 && reconnect(i,rc))
+                            {
+                                continue;
+                            }
+                            else
+                                dropconnection(i,2);
+                        }
                         else
                         {
                             lfd_m[i].lastact=now;
@@ -873,6 +907,7 @@ void poll_loop(int accsock)
 				}
 				else if (!strncmp(lfd_m[i].inbuf,"RTSP/1.0 200",12))
 				{
+				    lfd_m[i].count_reconnect=nr_reconnects;
 				    lfd_m[i].inbuf[lfd_m[i].inbuf_offset+len]=0;
 				    lfd_m[i].inbuf_offset=0;
                                     if (debug>1) fprintf(stderr,"---------------------------------------------- res <<<<<<<<<<<<<<<<<<<<<<<<<<< \n%s------------------------------------------------------------------------------\n",lfd_m[i].inbuf);
@@ -916,11 +951,12 @@ int main(int argc,char **argv)
     char *p;
 
     prg=argv[0];
-    while ((ch=getopt(argc,argv,"di:p:r:t:T:"))!= EOF)
+    while ((ch=getopt(argc,argv,"df:i:p:r:t:T:"))!= EOF)
     {
         switch(ch)
         {
             case 'd':   debug++; break;
+            case 'f':   nr_reconnects=atoi(optarg); break;
             case 'i':   srvip=optarg; break;
             case 'p':   lport=optarg; break;
             case 'r':   udp_recv_port=atoi(optarg); break;
@@ -943,6 +979,7 @@ int main(int argc,char **argv)
     {
         fprintf(stderr,"Using target SAT>IP server %s with port %s\n",target,port);
         fprintf(stderr,"Listening in address %s at port %s\n",srvip,lport);
+        fprintf(stderr,"Reconnecting to server enabled (max %d times between commands)\n",nr_reconnects);
         fprintf(stderr,"Configured RTP receive ports %d-%d\n",udp_recv_port,udp_recv_port+1);
         if (redir_rtp[0] != 0)
             fprintf(stderr,"Alternative RTP/RTCP target: %s\n",redir_rtp);


### PR DESCRIPTION
Advanced (and optional) reconnection functionality for the RTSP client socket when the remote SAT>IP server closes the socket (but the session continues).
This is useful almost in two scenarios:
- When the remote connection is over unreliable link and the TCP socket is closed time-to-time. With this option the socket is automatically reconnected.
- If the SAT>IP serves closes the socket after a short time of no data. This breaks the specs, but the session continues open, so we need to reconnect.