### PR TITLE
Improve LOG with timestamps

### DIFF
--- a/rtsp-proxy.c
+++ b/rtsp-proxy.c
@@ -1036,6 +1036,8 @@ int main(int argc,char **argv)
     DEBUG_TIME();
     fprintf(stderr,"* starting proxy at... %s \n",now_log);
     poll_loop(accsock);
+    DEBUG_TIME();
+    fprintf(stderr,"* closing proxy at... %s \n",now_log);
 
     exit(0);
 


### PR DESCRIPTION
This PR improves the LOG in two points:
- Removes the long lines of code when printing the dump of the content of the packets in the log.
- Include in all prints the current timestamp (that also improves the reading, as the content of the packets are not tabulated, but the rest has every time the timestamp before).
